### PR TITLE
Add support for Font Awesome icons

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -31,9 +31,48 @@
     wp_enqueue_script( 'themescript', get_template_directory_uri() . '/scripts/main.js' );
   });
 
+  // THEME Add Font Awesome
+  add_action('wp_enqueue_scripts', function() {
+    wp_enqueue_script( 'icons', 'https://kit.fontawesome.com/3b35bdd7e6.js' );
+  });
+
+  // THEME Set Font Awesome Icon Type
+  add_filter('fvt_icon_type', function($type) {
+    return $type ? $type : 'solid';
+  });
+
+  // THEME Add Font Awesome Shortcode
+  add_shortcode('i', function($atts) {
+    extract( shortcode_atts( array(
+      'type' => icon_type(),
+      'icon' => '',
+      'size' => '',
+    ), $atts ));
+
+    if ($size) {
+      $size = 'height: ' . $size . '; vertical-align: middle;';
+    } else {
+      $size = '';
+    }
+
+    return '<i style="' . $size . '" class="icon fa-' . $type . ' fa-' . $icon . '"></i>';
+  });
+
   // GDYMC Define modules folder location
   add_filter( 'gdymc_modules_folder', function ( $content ) {
     return get_template_directory() . '/modules';
+  });
+
+  // GDYMC Add Shortcode Support
+
+  add_filter( 'gdymc_contentfilter', function ( $content ) {
+
+    if(!gdymc_logged()):
+      return do_shortcode( $content );
+    else:
+      return $content;
+    endif;
+
   });
 
   // GDYMC Add gloabl appearance  settings
@@ -54,22 +93,3 @@
     $classes[] = 'background_' . $appearance;
     return $classes;
   });
-
-  add_action( 'add_meta_boxes', function () {
-    add_meta_box(
-        'fvw-ct-smtp-recipient-mail',
-        'Receipient Mail',
-        'fvw_ct_smtp_recipient_mail_html',
-        'option',
-        'normal',
-        'high',
-        null
-    );
-  });
-
-  function fvw_ct_smtp_recipient_mail_html() {
-    ?>
-    <label for="fvw-ct-smtp-recipient-mail-field">Description for this field</label>
-    <input name="fvw-ct-smtp-recipient-mail-field" id="fvw-ct-smtp-recipient-mail-field"></input>
-    <?php
-  }

--- a/includes/EasyInit/interface.php
+++ b/includes/EasyInit/interface.php
@@ -1,5 +1,15 @@
 <?php 
 
+  function icon_type() {
+    if (function_exists('get_field')) {
+      $ei_icon_type = get_field('fvt_icon_type', 'option');
+    }
+
+    $ei_icon_type = apply_filters('fvt_icon_type', $ei_icon_type);
+
+    return $ei_icon_type;
+  }
+
   function background_class($background) {
     $ei_header_background = 'dark';
     $ei_footer_background = 'dark';

--- a/sass/components/_button.scss
+++ b/sass/components/_button.scss
@@ -31,6 +31,14 @@ a, input[type="submit"] {
       background-color .3s $transition-fast,
       box-shadow .2s $transition-fast;
 
+    &.icon-left {
+      padding-left: calc(var(--fvt-inner-spacing) / 1.15);
+    }
+
+    &.icon-right {
+      padding-right: calc(var(--fvt-inner-spacing) / 1.15);
+    }
+
     &:hover {
       box-shadow: $box-shadow-medium;
     }

--- a/sass/components/_icon.scss
+++ b/sass/components/_icon.scss
@@ -1,0 +1,3 @@
+.icon {
+  aspect-ratio: 1;
+}

--- a/sass/components/index.scss
+++ b/sass/components/index.scss
@@ -3,3 +3,4 @@
 @import './footer';
 @import './button';
 @import './form';
+@import './icon';


### PR DESCRIPTION
- Adds base support for the font awesome icon library via Wordpress Shortcode within the editable text areas in the modules.

Closes #26 